### PR TITLE
Teamdev2-1_チーム情報編集およびユーザ削除に関する制限実装

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -30,18 +30,20 @@ class AssignsController < ApplicationController
       'リーダーは削除できません。'
     elsif Assign.where(user_id: assigned_user.id).count == 1
       'このユーザーはこのチームにしか所属していないため、削除できません。'
+    elsif current_user != assign.team.owner && current_user != assign.user
+      'チームリーダーかユーザー自身以外は削除できません。'
     elsif assign.destroy
       set_next_team(assign, assigned_user)
       'メンバーを削除しました。'
     else
       'なんらかの原因で、削除できませんでした。'
-    end    
-  end  
-  
+    end
+  end
+
   def email_reliable?(address)
     address.match(/\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i)
   end
-  
+
   def set_next_team(assign, assigned_user)
     another_team = Assign.find_by(user_id: assigned_user.id).team
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,7 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_team, only: %i[show edit update destroy]
+  before_action :team_owner, only: [:edit]
 
   def index
     @teams = Team.all
@@ -48,7 +49,6 @@ class TeamsController < ApplicationController
   end
 
   private
-
   def set_team
     @team = Team.friendly.find(params[:id])
   end
@@ -56,4 +56,11 @@ class TeamsController < ApplicationController
   def team_params
     params.fetch(:team, {}).permit %i[name icon icon_cache owner_id keep_team_id]
   end
+
+  def team_owner
+    unless current_user == @team.owner
+      redirect_to team_path, notice: "編集できるのはチームリーダーだけです。"
+    end
+  end
+
 end

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -14,7 +14,9 @@
       <tr>
         <td><%= team.name %></td>
         <td><%= link_to 'Show', team %></td>
-        <td><%= link_to 'Edit', edit_team_path(team) %></td>
+        <% if current_user == team.owner %>
+          <td><%= link_to 'Edit', edit_team_path(team) %></td>
+        <% end %>
         <td><%= link_to 'Destroy', team, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -10,7 +10,9 @@
               <%= image_tag default_img(@team.icon_url), class: 'img' %><br>
               <%= @team.name %>
             </div>
-            <%= link_to 'チーム情報を編集する', edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% if current_user == @team.owner %>
+              <%= link_to 'チーム情報を編集する', edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% end %>
           </div>
 
           <div class="col-md-8">
@@ -41,7 +43,12 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
-                      <td><%= link_to '削除', team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% if current_user == @team.owner %>
+                        <td><%= link_to '削除', team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% end %>
+                      <% if current_user.id == assign.user_id && current_user != @team.owner%>
+                        <td><%= link_to '削除', team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% end %>
                     </tr>
                   <% end %>
                 </tbody>


### PR DESCRIPTION
【課題内容】
◆Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること
◆TeamのeditはTeamのリーダー（オーナー）のみができるようにすること